### PR TITLE
Misc fixes

### DIFF
--- a/source/QuickStartUtils.cpp
+++ b/source/QuickStartUtils.cpp
@@ -93,7 +93,7 @@ bool getQuickBoot() {
 
         auto fileStream = new nn::sl::FileStream;
         auto *fsClient  = (FSClient *) memalign(0x40, sizeof(FSClient));
-		if (!fsClient) {
+        if (!fsClient) {
             DEBUG_FUNCTION_LINE("Couldn't alloc memory for fsClient.");
             return false;
         }
@@ -117,7 +117,7 @@ bool getQuickBoot() {
         delete fileStream;
 
         FSDelClient(fsClient, FS_ERROR_FLAG_NONE);
-		free(fsClient);
+        free(fsClient);
 
         nn::sl::Finalize();
 

--- a/source/QuickStartUtils.cpp
+++ b/source/QuickStartUtils.cpp
@@ -93,6 +93,10 @@ bool getQuickBoot() {
 
         auto fileStream = new nn::sl::FileStream;
         auto *fsClient  = (FSClient *) memalign(0x40, sizeof(FSClient));
+		if (!fsClient) {
+            DEBUG_FUNCTION_LINE("Couldn't alloc memory for fsClient.");
+            return false;
+        }
         memset(fsClient, 0, sizeof(*fsClient));
         FSAddClient(fsClient, FS_ERROR_FLAG_NONE);
 
@@ -113,6 +117,7 @@ bool getQuickBoot() {
         delete fileStream;
 
         FSDelClient(fsClient, FS_ERROR_FLAG_NONE);
+		free(fsClient);
 
         nn::sl::Finalize();
 

--- a/source/StorageUtils.cpp
+++ b/source/StorageUtils.cpp
@@ -40,7 +40,7 @@ static int numberUSBStorageDevicesConnected() {
     if (!buffer) {
         free(handle);
         free(config);
-		return -3;
+        return -3;
     }
     memset(buffer, 0, size);
 

--- a/source/StorageUtils.cpp
+++ b/source/StorageUtils.cpp
@@ -29,7 +29,7 @@ static int numberUSBStorageDevicesConnected() {
     memset(handle, 0, sizeof(UhsHandle));
     auto *config = (UhsConfig *) memalign(0x40, sizeof(UhsConfig));
     if (!config) {
-        free(config);
+        free(handle);
         return -2;
     }
     memset(config, 0, sizeof(UhsConfig));
@@ -37,9 +37,10 @@ static int numberUSBStorageDevicesConnected() {
     config->controller_num = 0;
     uint32_t size          = 5120;
     void *buffer           = memalign(0x40, size);
-    if (buffer == nullptr) {
+    if (!buffer) {
         free(handle);
         free(config);
+		return -3;
     }
     memset(buffer, 0, size);
 
@@ -51,7 +52,7 @@ static int numberUSBStorageDevicesConnected() {
         free(handle);
         free(config);
         free(buffer);
-        return -3;
+        return -4;
     }
 
     UhsInterfaceProfile profiles[10];
@@ -65,7 +66,7 @@ static int numberUSBStorageDevicesConnected() {
         free(handle);
         free(config);
         free(buffer);
-        return -4;
+        return -5;
     }
 
     auto found = 0;
@@ -79,7 +80,7 @@ static int numberUSBStorageDevicesConnected() {
     UhsClientClose(handle);
     free(handle);
     free(config);
-    free(config->buffer);
+    free(buffer);
     return found;
 }
 


### PR DESCRIPTION
fsClient didnt get freed and some confusion on variables on numberUSBStorageDevicesConnected function. If theyre required to be aligned, to make it simpler, maybe allocate 1 buffer to fit them all, something like:

#define ROUNDUP(x, align)  (((x) + ((align) - 1)) & ~((align) - 1))
uint32_t bufferSize =ROUNDUP(sizeof(UhsHandle), 0x40) + ROUNDUP(sizeof(UhsConfig), 0x40) + 5120;

or using 
#define ALIGN(align)       __attribute__((aligned(align)))
ALIGN(0x40) UhsHandle handle;
