### PR TITLE
Add vWii DRC Enabled Option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 .idea/
 cmake-build-debug/
 CMakeLists.txt
+.vscode/

--- a/source/BootUtils.cpp
+++ b/source/BootUtils.cpp
@@ -90,12 +90,17 @@ void handleAccountSelection() {
     nn::act::Finalize();
 }
 
-static void launchvWiiTitle(uint32_t titleId_low, uint32_t titleId_high) {
+static void launchvWiiTitle(uint32_t titleId_low, uint32_t titleId_high, bool drcEnabled) {
     // we need to init kpad for cmpt
     KPADInit();
 
     // Try to find a screen type that works
-    CMPTAcctSetScreenType(CMPT_SCREEN_TYPE_BOTH);
+    if (drcEnabled) {
+        CMPTAcctSetScreenType(CMPT_SCREEN_TYPE_BOTH);
+    } else {
+        CMPTAcctSetScreenType(CMPT_SCREEN_TYPE_TV);
+    }
+
     if (CMPTCheckScreenState() < 0) {
         CMPTAcctSetScreenType(CMPT_SCREEN_TYPE_DRC);
         if (CMPTCheckScreenState() < 0) {
@@ -117,11 +122,11 @@ static void launchvWiiTitle(uint32_t titleId_low, uint32_t titleId_high) {
     free(dataBuffer);
 }
 
-void bootvWiiMenu() {
-    launchvWiiTitle(0, 0);
+void bootvWiiMenu(bool drcEnabled) {
+    launchvWiiTitle(0, 0, drcEnabled);
 }
 
-void bootHomebrewChannel() {
+void bootHomebrewChannel(bool drcEnabled) {
     // fall back to booting the vWii system menu if anything fails
     uint64_t titleId = 0;
 
@@ -157,5 +162,5 @@ void bootHomebrewChannel() {
     }
 
     DEBUG_FUNCTION_LINE("Launching vWii title %016llx", titleId);
-    launchvWiiTitle((uint32_t) (titleId >> 32), (uint32_t) (titleId & 0xffffffff));
+    launchvWiiTitle((uint32_t) (titleId >> 32), (uint32_t) (titleId & 0xffffffff), drcEnabled);
 }

--- a/source/BootUtils.h
+++ b/source/BootUtils.h
@@ -6,6 +6,6 @@ void bootWiiUMenu();
 
 void bootHomebrewLauncher();
 
-void bootvWiiMenu();
+void bootvWiiMenu(bool drcEnabled);
 
-void bootHomebrewChannel();
+void bootHomebrewChannel(bool drcEnabled);

--- a/source/MenuUtils.cpp
+++ b/source/MenuUtils.cpp
@@ -136,7 +136,7 @@ int32_t handleMenuScreen(std::string &configPath, std::string &drcSettingPath, i
         } else if (vpad.trigger & VPAD_BUTTON_Y) {
             autoboot = selected;
             redraw   = true;
-        } else if (vpad.trigger & VPAD_BUTTON_B) {
+        } else if (vpad.trigger & VPAD_BUTTON_MINUS) {
             drcEnabled = !drcEnabled;
             redraw     = true;
         }
@@ -176,7 +176,7 @@ int32_t handleMenuScreen(std::string &configPath, std::string &drcSettingPath, i
             DrawUtils::setFontSize(18);
             DrawUtils::print(16, SCREEN_HEIGHT - 8, "\ue07d Navigate ");
             DrawUtils::print(SCREEN_WIDTH - 16, SCREEN_HEIGHT - 8, "\ue000 Choose", true);
-            const char *autobootHints = "\ue002 Clear Autoboot / \ue003 Select Autoboot / \ue001 Toggle vWii DRC";
+            const char *autobootHints = "\ue002 Clear Autoboot / \ue003 Select Autoboot / - Toggle vWii DRC";
             DrawUtils::print(SCREEN_WIDTH / 2 + DrawUtils::getTextWidth(autobootHints) / 2, SCREEN_HEIGHT - 8, autobootHints, true);
 
             DrawUtils::endDraw();

--- a/source/MenuUtils.h
+++ b/source/MenuUtils.h
@@ -27,6 +27,10 @@ int32_t readAutobootOption(std::string &configPath);
 
 void writeAutobootOption(std::string &configPath, int32_t autobootOption);
 
-int32_t handleMenuScreen(std::string &configPath, int32_t autobootOptionInput);
+bool readDrcEnabledOption(std::string &configPath);
+
+void writeDrcEnabledOption(std::string &configPath, bool drcEnabled);
+
+int32_t handleMenuScreen(std::string &configPath, std::string &drcSettingPath, int32_t autobootOptionInput, bool drcEnabledInput);
 
 nn::act::SlotNo handleAccountSelectScreen(const std::vector<std::shared_ptr<AccountInfo>> &data);

--- a/source/QuickStartUtils.cpp
+++ b/source/QuickStartUtils.cpp
@@ -204,7 +204,7 @@ bool getQuickBoot() {
 
         if (info.titleId == 0x0005001010004000L) { // OSv0
             DEBUG_FUNCTION_LINE("Launching vWii System Menu");
-            bootvWiiMenu();
+            bootvWiiMenu(true);
 
             return true;
         }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -38,8 +38,8 @@ int32_t main(int32_t argc, char **argv) {
         return 0;
     }
 
-    std::string configPath = "fs:/vol/exernal01/wiiu/autoboot.cfg";
-    std::string drcSettingPath = "fs:/vol/exernal01/wiiu/drcenabled.cfg";
+    std::string configPath = "fs:/vol/external01/wiiu/autoboot.cfg";
+    std::string drcSettingPath = "fs:/vol/external01/wiiu/drcenabled.cfg";
     if (argc >= 1) {
         configPath = std::string(argv[0]) + "/autoboot.cfg";
         drcSettingPath = std::string(argv[0]) + "/drcenabled.cfg";

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -39,8 +39,10 @@ int32_t main(int32_t argc, char **argv) {
     }
 
     std::string configPath = "fs:/vol/exernal01/wiiu/autoboot.cfg";
+    std::string drcSettingPath = "fs:/vol/exernal01/wiiu/drcenabled.cfg";
     if (argc >= 1) {
         configPath = std::string(argv[0]) + "/autoboot.cfg";
+        drcSettingPath = std::string(argv[0]) + "/drcenabled.cfg";
     }
 
     int32_t bootSelection = readAutobootOption(configPath);
@@ -49,7 +51,7 @@ int32_t main(int32_t argc, char **argv) {
     VPADRead(VPAD_CHAN_0, &vpad, 1, nullptr);
 
     if ((bootSelection == -1) || (vpad.hold & VPAD_BUTTON_PLUS)) {
-        bootSelection = handleMenuScreen(configPath, bootSelection);
+        bootSelection = handleMenuScreen(configPath, drcSettingPath, bootSelection, readDrcEnabledOption(drcSettingPath));
     }
 
     if (bootSelection >= 0) {
@@ -61,10 +63,10 @@ int32_t main(int32_t argc, char **argv) {
                 bootHomebrewLauncher();
                 break;
             case BOOT_OPTION_VWII_SYSTEM_MENU:
-                bootvWiiMenu();
+                bootvWiiMenu(readDrcEnabledOption(drcSettingPath));
                 break;
             case BOOT_OPTION_VWII_HOMEBREW_CHANNEL:
-                bootHomebrewChannel();
+                bootHomebrewChannel(readDrcEnabledOption(drcSettingPath));
                 break;
             default:
                 bootWiiUMenu();

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -38,10 +38,10 @@ int32_t main(int32_t argc, char **argv) {
         return 0;
     }
 
-    std::string configPath = "fs:/vol/external01/wiiu/autoboot.cfg";
+    std::string configPath     = "fs:/vol/external01/wiiu/autoboot.cfg";
     std::string drcSettingPath = "fs:/vol/external01/wiiu/drcenabled.cfg";
     if (argc >= 1) {
-        configPath = std::string(argv[0]) + "/autoboot.cfg";
+        configPath     = std::string(argv[0]) + "/autoboot.cfg";
         drcSettingPath = std::string(argv[0]) + "/drcenabled.cfg";
     }
 


### PR DESCRIPTION
So this binds the B button to a setting that will disable/enable the DRC (gamepad) when booting to vWii.
Might need some changes to code related to saving the setting but its a nice addition.