### PR TITLE
Add a update block warning screen

### DIFF
--- a/source/MenuUtils.h
+++ b/source/MenuUtils.h
@@ -8,9 +8,12 @@
 #include <string>
 #include <vector>
 
+#define UPDATE_SKIP_PATH         "fs:/vol/external01/wiiu/environments/skipUpdateWarn"
+
 #define COLOR_WHITE              Color(0xffffffff)
 #define COLOR_BLACK              Color(0, 0, 0, 255)
 #define COLOR_BACKGROUND         COLOR_BLACK
+#define COLOR_BACKGROUND_WARN    Color(255, 40, 0, 255)
 #define COLOR_TEXT               COLOR_WHITE
 #define COLOR_TEXT2              Color(0xB3ffffff)
 #define COLOR_AUTOBOOT           Color(0xaeea00ff)
@@ -31,3 +34,5 @@ void writeAutobootOption(std::string &configPath, int32_t autobootOption);
 int32_t handleMenuScreen(std::string &configPath, int32_t autobootOptionInput, const std::map<uint32_t, std::string> &menu);
 
 nn::act::SlotNo handleAccountSelectScreen(const std::vector<std::shared_ptr<AccountInfo>> &data);
+
+void handleUpdateWarningScreen();

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -5,6 +5,7 @@
 #include "StorageUtils.h"
 #include "logger.h"
 #include <coreinit/debug.h>
+#include <coreinit/filesystem_fsa.h>
 #include <gx2/state.h>
 #include <malloc.h>
 #include <mocha/mocha.h>
@@ -41,6 +42,20 @@ int32_t main(int32_t argc, char **argv) {
 
     if (Mocha_InitLibrary() != MOCHA_RESULT_SUCCESS) {
         OSFatal("AutobootModule: Mocha_InitLibrary failed");
+    }
+
+    FSAInit();
+    auto client = FSAAddClient(nullptr);
+    if (client > 0) {
+        if (Mocha_UnlockFSClientEx(client) == MOCHA_RESULT_SUCCESS) {
+            // test if the update folder exists
+            FSStat stat;
+            if (FSAGetStat(client, "/vol/storage_mlc01/sys/update", &stat) >= 0) {
+                handleUpdateWarningScreen();
+            }
+        }
+
+        FSADelClient(client);
     }
 
     bool showvHBL          = getVWiiHBLTitleId() != 0;


### PR DESCRIPTION
Adds this warning if the update folder still exists:
![Screenshot 2022-09-04 21-22-04](https://user-images.githubusercontent.com/12049776/188330121-2ada7755-3755-46da-94be-403375f39eee.png)

<b>Don't merge this yet until wiiu.hacks.guide is updated</b>