### PR TITLE
Add support for custom boot entries (either vWii or Wiiu)

### DIFF
--- a/source/BootUtils.h
+++ b/source/BootUtils.h
@@ -1,13 +1,20 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+
+void launchvWiiTitle(uint64_t titleId);
 
 void bootWiiUMenu();
 
 void bootHomebrewLauncher();
 
+void bootWiiuTitle(const std::string& hexId);
+
 void bootvWiiMenu();
 
 void bootHomebrewChannel();
+
+uint64_t getVWiiTitleId(const std::string& hexId);
 
 uint64_t getVWiiHBLTitleId();

--- a/source/MenuUtils.h
+++ b/source/MenuUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ACTAccountInfo.h"
+#include <array>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -20,18 +21,38 @@
 #define COLOR_BORDER             Color(204, 204, 204, 255)
 #define COLOR_BORDER_HIGHLIGHTED Color(0x3478e4ff)
 
+struct BootOption {
+    std::string title;
+    std::string hexId;
+    bool vWii;
+};
+
 enum {
-    BOOT_OPTION_WII_U_MENU,
+    BOOT_OPTION_WII_U_MENU = 0,
     BOOT_OPTION_HOMEBREW_LAUNCHER,
     BOOT_OPTION_VWII_SYSTEM_MENU,
     BOOT_OPTION_VWII_HOMEBREW_CHANNEL,
+
+    BOOT_OPTION_MAX_OPTIONS
 };
 
-int32_t readAutobootOption(std::string &configPath);
+constexpr std::array<const char*, BOOT_OPTION_MAX_OPTIONS> autoboot_base_config_strings{
+    "wiiu_menu",
+    "homebrew_launcher",
+    "vwii_system_menu",
+    "vwii_homebrew_channel",
+};
 
-void writeAutobootOption(std::string &configPath, int32_t autobootOption);
+extern std::vector<std::string> autoboot_config_strings;
+extern std::vector<BootOption> custom_boot_options;
 
-int32_t handleMenuScreen(std::string &configPath, int32_t autobootOptionInput, const std::map<uint32_t, std::string> &menu);
+void readBootOptionsFromSD(const std::string &configPath);
+
+int32_t readAutobootOption(const std::string &configPath);
+
+void writeAutobootOption(const std::string &configPath, int32_t autobootOption);
+
+int32_t handleMenuScreen(const std::string &configPath, int32_t autobootOptionInput, const std::map<uint32_t, std::string> &menu);
 
 nn::act::SlotNo handleAccountSelectScreen(const std::vector<std::shared_ptr<AccountInfo>> &data);
 


### PR DESCRIPTION
Allows adding custom boot entries by creating a file called bootOptions.cfg in the :sd/wiiu/environments/tiramisu/ folder.
An example of such file is:
```
Nintendont,0x57574e44,vWii
WiiUChat,0xA,wiiu
```
The above configuration will display two new entries in the boot menu:
- "Nintendont" (titleId 0x57574e44, vWii Channel)
- "WiiUChat" (titleId 0xA, WiiU Channel)

I didn't do anything to support scrolling entries but I think that might be too much.