### PR TITLE
try to mount usb at least once to fix virtual usb

### DIFF
--- a/source/StorageUtils.cpp
+++ b/source/StorageUtils.cpp
@@ -90,23 +90,17 @@ void initExternalStorage() {
         // the lib before actually using it.
         return;
     }
-    int connectedStorage = 0;
-    if ((connectedStorage = numberUSBStorageDevicesConnected()) <= 0) {
-        nn::spm::Initialize();
-        InitEmptyExternalStorage();
-        nn::spm::Finalize();
-        return;
-    }
+    int connectedStorage = numberUSBStorageDevicesConnected();
 
     DEBUG_FUNCTION_LINE("Connected StorageDevices = %d", connectedStorage);
 
     nn::spm::Initialize();
 
     nn::spm::StorageListItem items[0x20];
-    int tries  = 0;
+    
     bool found = false;
 
-    while (tries < 1200) { // Wait up to 20 seconds, like the Wii U Menu
+    for(int tries = 1200; tries; tries--) { // Wait up to 20 seconds, like the Wii U Menu
         int32_t numItems = nn::spm::GetStorageList(items, 0x20);
 
         DEBUG_FUNCTION_LINE("Number of items: %d", numItems);
@@ -127,12 +121,11 @@ void initExternalStorage() {
                 }
             }
         }
-        if (found || (connectedStorage == numItems)) {
+        if (found || (connectedStorage <= numItems)) {
             DEBUG_FUNCTION_LINE("Found all expected items, breaking.");
             break;
         }
         OSSleepTicks(OSMillisecondsToTicks(16));
-        tries++;
     }
     if (!found) {
         DEBUG_FUNCTION_LINE("USB Storage is connected but either it doesn't have a WFS partition or we ran into a timeout.");


### PR DESCRIPTION
If usb storage is simulated with an SD card and no real USB storage is connected, the AutobootModule didn't try to mount USB. That caused the Wii U menu to think a usb device was connected after boot and forcing a relaunch.

This PR lets the AUtobootModule still try at least once to mount USB in all cases.